### PR TITLE
Clean up leftover download and upload files

### DIFF
--- a/bot/helpers/uploader.py
+++ b/bot/helpers/uploader.py
@@ -8,6 +8,7 @@ from bot.logger import LOGGER
 from mutagen import File
 from mutagen.mp4 import MP4
 import re
+from bot.settings import bot_set
 
 async def track_upload(metadata, user):
     """
@@ -18,7 +19,7 @@ async def track_upload(metadata, user):
     """
     # Determine base path for different providers
     if "Apple Music" in metadata['filepath']:
-        base_path = os.path.join(Config.LOCAL_STORAGE, "Apple Music")
+        base_path = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']), "Apple Music")
     else:
         base_path = Config.LOCAL_STORAGE
     
@@ -71,7 +72,7 @@ async def music_video_upload(metadata, user):
     """
     # Determine base path for different providers
     if "Apple Music" in metadata['filepath']:
-        base_path = os.path.join(Config.LOCAL_STORAGE, "Apple Music")
+        base_path = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']), "Apple Music")
     else:
         base_path = Config.LOCAL_STORAGE
     
@@ -120,7 +121,7 @@ async def album_upload(metadata, user):
     """
     # Determine base path for different providers
     if "Apple Music" in metadata['folderpath']:
-        base_path = os.path.join(Config.LOCAL_STORAGE, "Apple Music")
+        base_path = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']), "Apple Music")
     else:
         base_path = Config.LOCAL_STORAGE
     
@@ -187,7 +188,7 @@ async def artist_upload(metadata, user):
     """
     # Determine base path for different providers
     if "Apple Music" in metadata['folderpath']:
-        base_path = os.path.join(Config.LOCAL_STORAGE, "Apple Music")
+        base_path = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']), "Apple Music")
     else:
         base_path = Config.LOCAL_STORAGE
     
@@ -248,7 +249,7 @@ async def playlist_upload(metadata, user):
     """
     # Determine base path for different providers
     if "Apple Music" in metadata['folderpath']:
-        base_path = os.path.join(Config.LOCAL_STORAGE, "Apple Music")
+        base_path = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']), "Apple Music")
     else:
         base_path = Config.LOCAL_STORAGE
     

--- a/bot/helpers/utils.py
+++ b/bot/helpers/utils.py
@@ -429,9 +429,16 @@ async def cleanup(user=None, metadata=None):
     if user:
         try:
             # Clean up Apple Music directory
-            apple_dir = os.path.join(Config.LOCAL_STORAGE, "Apple Music", str(user['user_id']))
+            apple_dir = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']), "Apple Music")
             if os.path.exists(apple_dir):
                 shutil.rmtree(apple_dir, ignore_errors=True)
+                # Remove parent user directory if now empty
+                user_dir = os.path.join(Config.LOCAL_STORAGE, str(user['user_id']))
+                try:
+                    if os.path.isdir(user_dir) and not os.listdir(user_dir):
+                        os.rmdir(user_dir)
+                except Exception:
+                    pass
         except Exception as e:
             LOGGER.info(f"Apple cleanup error: {str(e)}")
         


### PR DESCRIPTION
Corrects Apple Music download cleanup and aligns upload paths to prevent leftover files.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe34869d-131d-44d1-b864-998d9a95b90a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe34869d-131d-44d1-b864-998d9a95b90a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

