### PR TITLE
Implement apple music wrapper controls with 2fa handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,38 @@ sudo docker run -d --env-file .env --name siesta project-siesta
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I2I7FWQZ4)
 
 TON - `UQBBPkWSnbMWXrM6P-pb96wYxQzLjZ2hhuYfsO-N2pVmznCG`
+
+## Apple Wrapper Controls (Apple Music)
+
+- **Location**: `Settings -> Providers -> Apple Music`
+- **Buttons**:
+  - `🧩 Setup Wrapper`: Starts an interactive setup that asks for your Apple ID username and password, then runs the wrapper setup script with those credentials. If 2FA is required, the bot will detect it and prompt you to send the 2FA code, then continues automatically.
+  - `⏹️ Stop Wrapper`: Stops any running wrapper process. Includes a confirmation step to prevent accidental taps.
+
+### How Setup Works
+1. Tap `🧩 Setup Wrapper`.
+2. Send your Apple ID username when asked.
+3. Send your Apple ID password when asked.
+4. The bot runs the setup script with `USERNAME` and `PASSWORD` exported in the environment, equivalent to:
+   ```bash
+   USERNAME="your_username" PASSWORD="your_password" /usr/src/app/downloader/setup_wrapper.sh
+   ```
+5. If the wrapper requests 2FA, you will see a prompt. Send the 2FA code as a normal message within 3 minutes.
+6. On success, you'll get a confirmation. On failure, the last part of the script output is shown for debugging.
+
+### How Stop Works
+- Tap `⏹️ Stop Wrapper` -> Confirm. The bot runs:
+  ```bash
+  /usr/src/app/downloader/stop_wrapper.sh
+  ```
+- It kills wrapper processes and frees ports 10020/20020.
+
+### Configuration
+- Override script paths with env vars if needed:
+  - `APPLE_WRAPPER_SETUP_PATH` (default `/usr/src/app/downloader/setup_wrapper.sh`)
+  - `APPLE_WRAPPER_STOP_PATH` (default `/usr/src/app/downloader/stop_wrapper.sh`)
+
+### Notes & Security
+- Credentials are only used to start the setup process and are not stored by the bot.
+- You can cancel the flow any time by sending `/cancel`.
+- If 2FA prompt does not appear (rare), setup continues and completes automatically.

--- a/bot/helpers/buttons/settings.py
+++ b/bot/helpers/buttons/settings.py
@@ -166,6 +166,11 @@ def apple_button(formats):
     for fmt, label in formats.items():
         buttons.append([InlineKeyboardButton(label, callback_data=f"appleF_{fmt}")])
     buttons.append([InlineKeyboardButton("Quality Settings", callback_data="appleQ")])
+    # Wrapper controls
+    buttons.append([
+        InlineKeyboardButton("🧩 Setup Wrapper", callback_data="appleSetup"),
+        InlineKeyboardButton("⏹️ Stop Wrapper", callback_data="appleStop")
+    ])
     buttons.append([InlineKeyboardButton("🔙 Back", callback_data="providerPanel")])
     return InlineKeyboardMarkup(buttons)
 

--- a/bot/helpers/state.py
+++ b/bot/helpers/state.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict, Optional
+import asyncio
+
+class ConversationState:
+    def __init__(self):
+        self._states: Dict[int, Dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(self, user_id: int, stage: str, data: Optional[Dict[str, Any]] = None):
+        async with self._lock:
+            self._states[user_id] = {"stage": stage, "data": data or {}}
+
+    def start_sync(self, user_id: int, stage: str, data: Optional[Dict[str, Any]] = None):
+        self._states[user_id] = {"stage": stage, "data": data or {}}
+
+    async def clear(self, user_id: int):
+        async with self._lock:
+            self._states.pop(user_id, None)
+
+    def clear_sync(self, user_id: int):
+        self._states.pop(user_id, None)
+
+    async def get(self, user_id: int) -> Optional[Dict[str, Any]]:
+        # Read-only access without lock is fine for our use
+        return self._states.get(user_id)
+
+    def get_sync(self, user_id: int) -> Optional[Dict[str, Any]]:
+        return self._states.get(user_id)
+
+    async def set_stage(self, user_id: int, stage: str):
+        async with self._lock:
+            if user_id in self._states:
+                self._states[user_id]["stage"] = stage
+
+    async def set_data(self, user_id: int, key: str, value: Any):
+        async with self._lock:
+            if user_id not in self._states:
+                self._states[user_id] = {"stage": "", "data": {}}
+            self._states[user_id].setdefault("data", {})[key] = value
+
+    async def update(self, user_id: int, stage: Optional[str] = None, **kwargs):
+        async with self._lock:
+            if user_id not in self._states:
+                self._states[user_id] = {"stage": stage or "", "data": {}}
+            if stage is not None:
+                self._states[user_id]["stage"] = stage
+            if kwargs:
+                self._states[user_id].setdefault("data", {}).update(kwargs)
+
+conversation_state = ConversationState()

--- a/bot/modules/provider_settings.py
+++ b/bot/modules/provider_settings.py
@@ -63,6 +63,7 @@ async def apple_cb(c, cb: CallbackQuery):
         await edit_message(
             cb.message,
             "🍎 **Apple Music Settings**\n\n"
+            "Use the buttons below to configure formats, quality, and manage the Wrapper service.\n\n"
             "**Available Formats:**\n"
             "- ALAC: Apple Lossless Audio Codec\n"
             "- Dolby Atmos: Spatial audio experience\n\n"
@@ -117,6 +118,50 @@ async def apple_set_quality_cb(c, cb: CallbackQuery):
         set_db.set_variable(f'APPLE_{format_type.upper()}_QUALITY', quality)
         setattr(Config, f'APPLE_{format_type.upper()}_QUALITY', quality)
         await apple_quality_cb(c, cb)
+
+
+# Apple Wrapper: Stop with confirmation
+@Client.on_callback_query(filters.regex(pattern=r"^appleStop$"))
+async def apple_wrapper_stop_cb(c: Client, cb: CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        # Ask for confirmation
+        buttons = InlineKeyboardMarkup([
+            [InlineKeyboardButton("✅ Confirm Stop", callback_data="appleStopConfirm")],
+            [InlineKeyboardButton("❌ Cancel", callback_data="appleP")]
+        ])
+        await edit_message(cb.message, "Are you sure you want to stop the Wrapper?", buttons)
+
+
+@Client.on_callback_query(filters.regex(pattern=r"^appleStopConfirm$"))
+async def apple_wrapper_stop_confirm_cb(c: Client, cb: CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        from config import Config as Cfg
+        import asyncio
+        await c.answer_callback_query(cb.id, "Stopping wrapper...", show_alert=False)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "/bin/bash", Cfg.APPLE_WRAPPER_STOP_PATH,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await proc.communicate()
+            out = stdout.decode(errors='ignore')
+            err = stderr.decode(errors='ignore')
+            text = "⏹️ Wrapper stop result:\n\n" + (out.strip() or err.strip() or "Done.")
+        except Exception as e:
+            text = f"❌ Failed to stop wrapper: {e}"
+        await edit_message(cb.message, text, InlineKeyboardMarkup([[InlineKeyboardButton("🔙 Back", callback_data="appleP")]]))
+
+
+# Apple Wrapper: Setup flow entry (asks for username then password)
+@Client.on_callback_query(filters.regex(pattern=r"^appleSetup$"))
+async def apple_wrapper_setup_cb(c: Client, cb: CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        # Explain flow
+        await edit_message(cb.message, "We'll set up the Wrapper. Please send your Apple ID username.\n\nYou can cancel anytime by sending /cancel.", InlineKeyboardMarkup([[InlineKeyboardButton("❌ Cancel", callback_data="appleP")]]))
+        # Mark state for this user
+        from ..helpers.state import conversation_state
+        await conversation_state.start(cb.from_user.id, "apple_setup_username", {"chat_id": cb.message.chat.id, "msg_id": cb.message.id})
 
 
 #----------------

--- a/bot/modules/telegram_setting.py
+++ b/bot/modules/telegram_setting.py
@@ -7,8 +7,11 @@ from ..settings import bot_set
 from ..helpers.translations import lang_available
 from ..helpers.buttons.settings import *
 from ..helpers.database.pg_impl import set_db
-from ..helpers.message import edit_message, check_user
-
+from ..helpers.message import edit_message, check_user, send_message, fetch_user_details
+from ..helpers.state import conversation_state
+from config import Config
+import asyncio
+import os
 
 
 @Client.on_callback_query(filters.regex(pattern=r"^tgPanel"))
@@ -77,3 +80,99 @@ async def set_language_cb(client, cb:CallbackQuery):
             await language_panel_cb(client, cb)
         except:
             pass
+
+
+@Client.on_message(filters.text & ~filters.command(["start", "settings", "download", "auth", "ban", "log", "cancel"]))
+async def handle_text_input(c: Client, msg: Message):
+    state = await conversation_state.get(msg.from_user.id)
+    if not state:
+        return
+
+    stage = state.get("stage")
+    data = state.get("data", {})
+
+    if stage == "apple_setup_username":
+        await conversation_state.update(msg.from_user.id, stage="apple_setup_password", username=msg.text.strip())
+        await send_message(msg, "Now send your Apple ID password. You can cancel with /cancel")
+        return
+
+    if stage == "apple_setup_password":
+        await conversation_state.update(msg.from_user.id, stage="apple_setup_running", password=msg.text.strip())
+        await send_message(msg, "Running setup... If 2FA is required, I'll ask for it.")
+        # Start the setup process and monitor for 2FA
+        asyncio.create_task(_run_wrapper_setup_flow(c, msg))
+        return
+
+    if stage == "apple_setup_need_2fa":
+        code = msg.text.strip()
+        await conversation_state.update(msg.from_user.id, stage="apple_setup_running", twofa=code)
+        await send_message(msg, "Received 2FA code. Continuing...")
+        # Signal the running process to consume 2FA code
+        _pending = data.get("_pending_2fa")
+        if _pending and not _pending.done():
+            _pending.set_result(code)
+        return
+
+@Client.on_message(filters.command(["cancel"]))
+async def cancel_flow(c: Client, msg: Message):
+    await conversation_state.clear(msg.from_user.id)
+    await send_message(msg, "Cancelled current operation.")
+
+async def _run_wrapper_setup_flow(c: Client, msg: Message):
+    user_id = msg.from_user.id
+    state = await conversation_state.get(user_id)
+    if not state:
+        return
+    data = state.get("data", {})
+    username = data.get("username")
+    password = data.get("password")
+
+    try:
+        # Launch the setup script with environment vars
+        proc = await asyncio.create_subprocess_exec(
+            "/bin/bash", Config.APPLE_WRAPPER_SETUP_PATH,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            stdin=asyncio.subprocess.PIPE,
+            env={**os.environ, "USERNAME": username, "PASSWORD": password},
+        )
+
+        pending_2fa_future = None  # type: asyncio.Future | None
+        buffer = ""
+        while True:
+            chunk = await proc.stdout.read(1024)
+            if not chunk:
+                break
+            text = chunk.decode(errors='ignore')
+            buffer += text
+            # Detect 2FA prompt in output
+            if "2FA" in text or "2fa" in text or "2FA code" in text:
+                if not pending_2fa_future:
+                    pending_2fa_future = asyncio.get_event_loop().create_future()
+                    await conversation_state.update(user_id, stage="apple_setup_need_2fa", _pending_2fa=pending_2fa_future)
+                    await send_message(msg, "Please send your 2FA code.")
+                    # Wait for user to respond, with timeout
+                    try:
+                        code = await asyncio.wait_for(pending_2fa_future, timeout=180)
+                    except asyncio.TimeoutError:
+                        await send_message(msg, "2FA timed out. Cancelling setup.")
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass
+                        await conversation_state.clear(user_id)
+                        return
+                    # Write code to process stdin with newline
+                    if proc.stdin is not None:
+                        proc.stdin.write((code + "\n").encode())
+                        await proc.stdin.drain()
+
+        rc = await proc.wait()
+        if rc == 0:
+            await send_message(msg, "✅ Wrapper setup completed.")
+        else:
+            await send_message(msg, f"❌ Wrapper setup failed. Exit code {rc}.\n\nOutput:\n{buffer[-2000:]}")
+    except Exception as e:
+        await send_message(msg, f"❌ Error running setup: {e}")
+    finally:
+        await conversation_state.clear(user_id)

--- a/config.py
+++ b/config.py
@@ -94,3 +94,7 @@ class Config:
     PLAYLIST_ZIP          = getenv("PLAYLIST_ZIP", "False")               # True or False
     ARTIST_ZIP            = getenv("ARTIST_ZIP", "False")                 # True or False
     RCLONE_LINK_OPTIONS   = getenv("RCLONE_LINK_OPTIONS", "Index")        # False, Index, RCLONE, or Both
+
+    # Apple Wrapper Scripts
+    APPLE_WRAPPER_SETUP_PATH = getenv("APPLE_WRAPPER_SETUP_PATH", "/usr/src/app/downloader/setup_wrapper.sh")
+    APPLE_WRAPPER_STOP_PATH  = getenv("APPLE_WRAPPER_STOP_PATH", "/usr/src/app/downloader/stop_wrapper.sh")

--- a/sample.env
+++ b/sample.env
@@ -57,6 +57,9 @@ INSTALLER_PATH=/usr/src/app/downloader/install_am_downloader.sh
 APPLE_DEFAULT_FORMAT=alac  # alac or atmos
 APPLE_ALAC_QUALITY=192000  # 192000, 256000, 320000
 APPLE_ATMOS_QUALITY=2768   # Only one option for Atmos
+# Apple Wrapper script paths (optional)
+APPLE_WRAPPER_SETUP_PATH=/usr/src/app/downloader/setup_wrapper.sh
+APPLE_WRAPPER_STOP_PATH=/usr/src/app/downloader/stop_wrapper.sh
 
 # Upload Mode: Telegram, RCLONE, or Local
 UPLOAD_MODE=Telegram


### PR DESCRIPTION
Adds Apple Music wrapper control buttons to manage the service, including interactive setup with credential and 2FA handling.

The setup flow is interactive, collecting username and password, then executing the wrapper script. It dynamically detects if the script prompts for a 2FA code, asks the user for it, and feeds it back to the running script, providing a complete in-bot setup experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ad6268f-43e2-4128-93c0-e071c534bf4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ad6268f-43e2-4128-93c0-e071c534bf4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

