### PR TITLE
Make telegram id easily copyable

### DIFF
--- a/bot/helpers/message.py
+++ b/bot/helpers/message.py
@@ -4,6 +4,7 @@ import re
 
 from pyrogram.types import Message
 from pyrogram.errors import MessageNotModified, FloodWait
+from pyrogram.enums import ParseMode
 
 from bot.tgclient import aio
 from bot.settings import bot_set
@@ -106,7 +107,8 @@ async def send_message(user, item, itype='text', caption=None, markup=None, chat
                 text=item,
                 reply_to_message_id=user['r_id'],
                 reply_markup=markup,
-                disable_web_page_preview=True
+                disable_web_page_preview=True,
+                parse_mode=ParseMode.HTML
             )
         elif itype == 'doc':
             msg = await aio.send_document(
@@ -173,7 +175,8 @@ async def edit_message(msg:Message, text, markup=None, antiflood=True):
         edited = await msg.edit_text(
             text=text,
             reply_markup=markup,
-            disable_web_page_preview=True
+            disable_web_page_preview=True,
+            parse_mode=ParseMode.HTML
         )
         return edited
     except MessageNotModified:

--- a/bot/modules/download.py
+++ b/bot/modules/download.py
@@ -49,7 +49,9 @@ async def download_track(c, msg: Message):
             state = await task_manager.create(user, label="Download")
             user['task_id'] = state.task_id
             user['cancel_event'] = state.cancel_event
-            user['bot_msg'] = await send_message(msg, f"Starting download…\nID: `{state.task_id}`\nUse /cancel {state.task_id} to stop.")
+            user['bot_msg'] = await send_message(msg, f"Starting download…\nUse /cancel <code>{state.task_id}</code> to stop.")
+            # Send ID in a separate, easily copyable message
+            await send_message(user, f"Task ID:\n<code>{state.task_id}</code>")
             try:
                 await start_link(link, user, options)
                 await send_message(user, lang.s.TASK_COMPLETED)

--- a/bot/providers/apple.py
+++ b/bot/providers/apple.py
@@ -46,7 +46,7 @@ class AppleMusicProvider:
 
         # Initialize progress reporter
         from bot.helpers.progress import ProgressReporter
-        label = f"Apple Music • ID:{user.get('task_id','?')}"
+        label = f"Apple Music • ID: {user.get('task_id','?')}"
         reporter = ProgressReporter(user['bot_msg'], label=label)
         user['progress'] = reporter
         await reporter.set_stage("Preparing")


### PR DESCRIPTION
Make Telegram task IDs easily copiable by sending them in a separate message formatted as a code block.

Previously, users had to copy the entire status message to extract the task ID, which was cumbersome. This change improves usability by providing the ID in a dedicated, easily selectable format.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a618846-3206-463d-a91a-33acd03bf564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a618846-3206-463d-a91a-33acd03bf564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

