### PR TITLE
Browse rclone mounted remote files and folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 WORKDIR /usr/src/app
 
 RUN apt-get update -qq && \
-    apt-get install -qq -y ffmpeg gcc libffi-dev && \
+    apt-get install -qq -y ffmpeg gcc libffi-dev fuse3 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install build dependencies and rclone in a separate stage

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The bot includes a full Rclone integration accessible from Telegram.
 
 ### Where files are stored
 
-- `rclone.conf` path: `./rclone.conf` (bot checks `/workspace/rclone.conf` too)
+- `rclone.conf` path: `/workspace/rclone.conf` preferred; falls back to `./rclone.conf` if present
 - Destination: `RCLONE_DEST` stored in DB (overrides `.env` at runtime)
 
 ### Troubleshooting

--- a/bot/helpers/uploader.py
+++ b/bot/helpers/uploader.py
@@ -418,7 +418,8 @@ async def rclone_upload(user, path, base_path):
     index_link = None
 
     if bot_set.link_options in ['RCLONE', 'Both']:
-        cmd = f'rclone link --config ./rclone.conf "{Config.RCLONE_DEST}/{relative_path}"'
+        cfg = '/workspace/rclone.conf' if os.path.exists('/workspace/rclone.conf') else ('./rclone.conf' if os.path.exists('./rclone.conf') else '')
+        cmd = f'rclone link --config {cfg} "{Config.RCLONE_DEST}/{relative_path}"' if cfg else f'rclone link "{Config.RCLONE_DEST}/{relative_path}"'
         task = await asyncio.create_subprocess_shell(
             cmd,
             stdout=asyncio.subprocess.PIPE,

--- a/bot/helpers/utils.py
+++ b/bot/helpers/utils.py
@@ -170,7 +170,8 @@ async def create_link(path, basepath):
     index_link = None
 
     if bot_set.link_options in ['RCLONE', 'Both']:
-        cmd = f'rclone link --config ./rclone.conf "{Config.RCLONE_DEST}/{path}"'
+        cfg = '/workspace/rclone.conf' if os.path.exists('/workspace/rclone.conf') else ('./rclone.conf' if os.path.exists('./rclone.conf') else '')
+        cmd = f'rclone link --config {cfg} "{Config.RCLONE_DEST}/{path}"' if cfg else f'rclone link "{Config.RCLONE_DEST}/{path}"'
         task = await asyncio.create_subprocess_shell(
             cmd,
             stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
Fix Rclone remote browser and standardize config path resolution to enable browsing, setting paths, and cloud-to-cloud operations.

The existing Rclone browser was unable to display items due to incorrect state handling and inconsistent Rclone config file path usage. This PR ensures the browser correctly accesses conversation state data, implements a robust config path resolver used across all Rclone commands (browse, link, mount, copy/move), and installs `fuse3` in the Dockerfile to support Rclone mounts.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5d78824-face-433b-8a62-c0b111d60c5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5d78824-face-433b-8a62-c0b111d60c5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

