### PR TITLE
Clarify rclone config file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,11 @@ Notes:
 
 - Remote → Local (Leech)
   - Open: Settings -> Rclone -> 📥 Remote → Local (Leech)
-  - Pick a remote, select a file or folder; the bot runs `rclone copy` to local storage under `${LOCAL_STORAGE}/{user_id}/leech`.
+  - Pick a remote, then select a file or folder.
+  - The bot first runs `rclone copy` to a unique local session directory: `${LOCAL_STORAGE}/{user_id}/leech/{session}`.
+  - After download completes, all files from that session are uploaded to Telegram (as documents) with progress.
+  - Files larger than Telegram’s ~2 GB limit are skipped with a notice.
+  - When upload finishes, the session folder is automatically cleaned up.
   - Progress and Cancel: progress appears inline; tap Cancel to stop.
 
 - Sync (source → destination identical)

--- a/bot/modules/rclone.py
+++ b/bot/modules/rclone.py
@@ -17,6 +17,7 @@ from ..helpers.database.pg_impl import set_db
 from ..settings import bot_set
 from config import Config
 from bot.logger import LOGGER
+from bot.tgclient import aio
 
 PAGE_SIZE = 10
 


### PR DESCRIPTION
Fix `NameError` in rclone module by importing `aio` client.

The `aio` client instance was used in `bot/modules/rclone.py` without being imported, causing a `NameError` during rclone operations. Importing it resolves the crash.

---
<a href="https://cursor.com/background-agent?bcId=bc-0156bafe-2a89-4e24-99c9-72d17b63bac1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0156bafe-2a89-4e24-99c9-72d17b63bac1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

